### PR TITLE
Downgrade to go 1.16

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/meka-dev/mekatek-go
 
-go 1.18
+go 1.16 // tendermint/tendermint v0.34.19 uses go 1.16

--- a/mekabuild/types.go
+++ b/mekabuild/types.go
@@ -111,7 +111,7 @@ func RegisterChallengeSignableBytes(ch []byte) []byte {
 	return sb.Bytes()
 }
 
-func mustEncode(w io.Writer, v any) {
+func mustEncode(w io.Writer, v interface{}) {
 	if err := binary.Write(w, binary.LittleEndian, v); err != nil {
 		panic(fmt.Errorf("encode %T (%v): %w", v, v, err))
 	}


### PR DESCRIPTION
The tracking version of Tendermint used by Osmosis is still on 1.16.